### PR TITLE
Feature/entity types per property type

### DIFF
--- a/src/containers/edm/propertytypes/PropertyTypeDetailsContainer.js
+++ b/src/containers/edm/propertytypes/PropertyTypeDetailsContainer.js
@@ -98,11 +98,13 @@ class PropertyTypeDetailsContainer extends React.Component<Props> {
 
     // This does a lookup in all entitySets to check if it utilizes the propertyType
     // Way too time intensive? Couldn't think of another way with existing API
-    for (let entityType of entityTypeIds) {
-      if(entityType.get('properties').includes(propertyTypeId)) {
-        matchedEntityTypeIds.add(entityType.get('id'));
-      }
-    }
+    entityTypeIds
+      .forEach((entityType) => {
+        if (entityType.get('properties').includes(propertyTypeId)) {
+          matchedEntityTypeIds.add(entityType.get('id'));
+        }
+      });
+
     // Following code requires an immutable set, so it is converted
     matchedEntityTypeIds = Immutable.Set(matchedEntityTypeIds);
 

--- a/src/containers/edm/propertytypes/PropertyTypeDetailsContainer.js
+++ b/src/containers/edm/propertytypes/PropertyTypeDetailsContainer.js
@@ -129,12 +129,10 @@ class PropertyTypeDetailsContainer extends React.Component<Props> {
 
 function mapStateToProps(state :Map<*, *>, ownProps) :Object {
   const propertyTypeId = ownProps.propertyType.get('id');
-  const entityTypes :OrderedSet<string> = state.getIn(['edm', 'entityTypes', 'entityTypes'], List())
-    .toOrderedSet()
+  const entityTypes :List<string> = state.getIn(['edm', 'entityTypes', 'entityTypes'], List())
     .filter((entityType :Map<*, *>) => {
       return entityType.get('properties').includes(propertyTypeId);
-    })
-    .toList();
+    });
   return {
     entityTypes
   };

--- a/src/containers/edm/propertytypes/PropertyTypeDetailsContainer.js
+++ b/src/containers/edm/propertytypes/PropertyTypeDetailsContainer.js
@@ -4,7 +4,7 @@
 
 import React from 'react';
 
-import { Map } from 'immutable';
+import { Map, List } from 'immutable';
 import { AuthUtils } from 'lattice-auth';
 import { EntityDataModelApiActionFactory } from 'lattice-sagas';
 import { bindActionCreators } from 'redux';
@@ -36,6 +36,8 @@ type Props = {
     deletePropertyType :RequestSequence;
   };
   propertyType :Map<*, *>;
+  entityTypes :List<Map<*, *>>;
+  entityTypesById :Map<string, number>;
 };
 
 class PropertyTypeDetailsContainer extends React.Component<Props> {
@@ -91,16 +93,16 @@ class PropertyTypeDetailsContainer extends React.Component<Props> {
     const ptPII :boolean = this.props.propertyType.get('piiField', false);
     const piiAsString :string = ptPII === true ? 'true' : 'false';
 
-    const entityTypes :List<Map<*, *>> = entityTypeIds
-      .map((entityTypeId :string) => {
-        const index :number = this.props.entityTypesById.get(entityTypeId, -1);
-        if (index === -1) {
-          return Map();
-        }
-        return this.props.entityTypes.get(index, Map());
-      })
-      .toList();
-      
+    // const entityTypes :List<Map<*, *>> = entityTypeIds
+    //   .map((entityTypeId :string) => {
+    //     const index :number = this.props.entityTypesById.get(entityTypeId, -1);
+    //     if (index === -1) {
+    //       return Map();
+    //     }
+    //     return this.props.entityTypes.get(index, Map());
+    //   })
+    //   .toList();
+
     return (
       <div>
         <h1>PropertyType Details</h1>
@@ -135,7 +137,7 @@ class PropertyTypeDetailsContainer extends React.Component<Props> {
           <h2>Analyzer</h2>
           <p>{ this.props.propertyType.get('analyzer') }</p>
         </section>
-        { this.renderEntityTypesSection(entityTypes) }
+        {/* this.renderEntityTypesSection(entityTypes) */}
         {
           AuthUtils.isAuthenticated() && AuthUtils.isAdmin()
             ? (
@@ -150,6 +152,14 @@ class PropertyTypeDetailsContainer extends React.Component<Props> {
   }
 }
 
+function mapStateToProps(state :Map<*, *>) :Object {
+
+  return {
+    entityTypes: state.getIn(['edm', 'entityTypes', 'entityTypes'], List()),
+    entityTypesById: state.getIn(['edm', 'entityTypes', 'entityTypesById'], Map())
+  };
+}
+
 function mapDispatchToProps(dispatch :Function) :Object {
 
   const actions = {
@@ -161,4 +171,4 @@ function mapDispatchToProps(dispatch :Function) :Object {
   };
 }
 
-export default connect(null, mapDispatchToProps)(PropertyTypeDetailsContainer);
+export default connect(mapStateToProps, mapDispatchToProps)(PropertyTypeDetailsContainer);

--- a/src/containers/edm/propertytypes/PropertyTypeDetailsContainer.js
+++ b/src/containers/edm/propertytypes/PropertyTypeDetailsContainer.js
@@ -89,10 +89,21 @@ class PropertyTypeDetailsContainer extends React.Component<Props> {
     if (!this.props.propertyType || this.props.propertyType.isEmpty()) {
       return null;
     }
-
     const ptPII :boolean = this.props.propertyType.get('piiField', false);
     const piiAsString :string = ptPII === true ? 'true' : 'false';
+    const entityTypeIds :OrderedSet<string> = this.props.entityTypes.toOrderedSet();
 
+    const propertyTypeId = this.props.propertyType.get('id');
+    const matchedEntityTypeIds = []
+    for (let entityType of entityTypeIds) {
+      for (let propertyId of entityType.get('properties')) {
+        if (propertyTypeId == propertyId) {
+          console.log('its a match');
+          matchedEntityTypeIds.push(propertyId);
+        }
+      }
+    }
+    console.log(matchedEntityTypeIds);
     // const entityTypes :List<Map<*, *>> = entityTypeIds
     //   .map((entityTypeId :string) => {
     //     const index :number = this.props.entityTypesById.get(entityTypeId, -1);

--- a/src/containers/edm/propertytypes/PropertyTypeDetailsContainer.js
+++ b/src/containers/edm/propertytypes/PropertyTypeDetailsContainer.js
@@ -4,8 +4,7 @@
 
 import React from 'react';
 
-import { Map, List } from 'immutable';
-import Immutable from 'immutable'
+import Immutable, { Map, List } from 'immutable';
 import { AuthUtils } from 'lattice-auth';
 import { EntityDataModelApiActionFactory } from 'lattice-sagas';
 import { bindActionCreators } from 'redux';

--- a/src/containers/edm/propertytypes/PropertyTypeDetailsContainer.js
+++ b/src/containers/edm/propertytypes/PropertyTypeDetailsContainer.js
@@ -4,7 +4,7 @@
 
 import React from 'react';
 
-import Immutable, { Map, List } from 'immutable';
+import { Map, List } from 'immutable';
 import { AuthUtils } from 'lattice-auth';
 import { EntityDataModelApiActionFactory } from 'lattice-sagas';
 import { bindActionCreators } from 'redux';
@@ -78,14 +78,6 @@ class PropertyTypeDetailsContainer extends React.Component<Props> {
     const ptPII :boolean = this.props.propertyType.get('piiField', false);
     const piiAsString :string = ptPII === true ? 'true' : 'false';
 
-    const propertyTypeId = this.props.propertyType.get('id');
-    const entityTypes :OrderedSet<string> = this.props.entityTypes
-      .toOrderedSet()
-      .filter((entityType :Map<*, *>) => {
-        return entityType.get('properties').includes(propertyTypeId);
-      })
-      .toList();
-
     return (
       <div>
         <h1>PropertyType Details</h1>
@@ -120,7 +112,7 @@ class PropertyTypeDetailsContainer extends React.Component<Props> {
           <h2>Analyzer</h2>
           <p>{ this.props.propertyType.get('analyzer') }</p>
         </section>
-        { this.renderEntityTypesSection(entityTypes) }
+        { this.renderEntityTypesSection(this.props.entityTypes) }
         {
           AuthUtils.isAuthenticated() && AuthUtils.isAdmin()
             ? (
@@ -135,8 +127,14 @@ class PropertyTypeDetailsContainer extends React.Component<Props> {
   }
 }
 
-function mapStateToProps(state :Map<*, *>) :Object {
-  const entityTypes = state.getIn(['edm', 'entityTypes', 'entityTypes'], List());
+function mapStateToProps(state :Map<*, *>, ownProps) :Object {
+  const propertyTypeId = ownProps.propertyType.get('id');
+  const entityTypes :OrderedSet<string> = state.getIn(['edm', 'entityTypes', 'entityTypes'], List())
+    .toOrderedSet()
+    .filter((entityType :Map<*, *>) => {
+      return entityType.get('properties').includes(propertyTypeId);
+    })
+    .toList();
   return {
     entityTypes
   };

--- a/src/containers/edm/propertytypes/PropertyTypeDetailsContainer.js
+++ b/src/containers/edm/propertytypes/PropertyTypeDetailsContainer.js
@@ -55,30 +55,17 @@ class PropertyTypeDetailsContainer extends React.Component<Props> {
       return null;
     }
 
-    let entityTypesDataTable :React$Node = (
+    const entityTypesDataTable :React$Node = (
       <AbstractTypeDataTable
           abstractTypes={entityTypes}
+          highlightOnHover
           maxHeight={500}
           workingAbstractTypeType={AbstractTypes.EntityTypes} />
     );
 
-    if (AuthUtils.isAuthenticated() && AuthUtils.isAdmin()) {
-      entityTypesDataTable = (
-        <AbstractTypeDataTable
-            abstractTypes={entityTypes}
-            highlightOnHover
-            maxHeight={500}
-            onAbstractTypeRemove={this.handleOnEntityTypeRemove}
-            onReorder={this.handleOnEntityTypeReorder}
-            orderable
-            showRemoveColumn
-            workingAbstractTypeType={AbstractTypes.EntityType} />
-      );
-    }
-
     return (
       <section>
-        <h2>EntityTypes</h2>
+        <h2>EntityTypes Utilizing this PropertyType</h2>
         { entityTypesDataTable }
       </section>
     );

--- a/src/containers/edm/propertytypes/PropertyTypeDetailsContainer.js
+++ b/src/containers/edm/propertytypes/PropertyTypeDetailsContainer.js
@@ -94,17 +94,14 @@ class PropertyTypeDetailsContainer extends React.Component<Props> {
     const piiAsString :string = ptPII === true ? 'true' : 'false';
     // This gathers ALL entityTypes from the EDM
     const entityTypeIds :OrderedSet<string> = this.props.entityTypes.toOrderedSet();
-
     const propertyTypeId = this.props.propertyType.get('id');
     let matchedEntityTypeIds :OrderedSet<string> = new Set([]);
 
-    // This loops through all entitySets to check if it utilizes the propertyType
-    // This will likely be way too time intensive, couldn't think of another way with existing API
+    // This does a lookup in all entitySets to check if it utilizes the propertyType
+    // Way too time intensive? Couldn't think of another way with existing API
     for (let entityType of entityTypeIds) {
-      for (let propertyId of entityType.get('properties')) {
-        if (propertyTypeId == propertyId) {
-          matchedEntityTypeIds.add(entityType.get('id'));
-        }
+      if(entityType.get('properties').includes(propertyTypeId)) {
+        matchedEntityTypeIds.add(entityType.get('id'));
       }
     }
     // Following code requires an immutable set, so it is converted

--- a/src/containers/edm/propertytypes/PropertyTypeDetailsContainer.js
+++ b/src/containers/edm/propertytypes/PropertyTypeDetailsContainer.js
@@ -11,6 +11,7 @@ import { bindActionCreators } from 'redux';
 import { connect } from 'react-redux';
 
 import AbstractTypes from '../../../utils/AbstractTypes';
+import AbstractTypeDataTable from '../../../components/datatable/AbstractTypeDataTable';
 import AbstractTypeFieldDescription from '../AbstractTypeFieldDescription';
 import AbstractTypeFieldTitle from '../AbstractTypeFieldTitle';
 import AbstractTypeFieldType from '../AbstractTypeFieldType';
@@ -46,6 +47,41 @@ class PropertyTypeDetailsContainer extends React.Component<Props> {
     }
   }
 
+  renderEntityTypesSection = (entityTypes :List<Map<*, *>>) => {
+
+    if (entityTypes.isEmpty()) {
+      return null;
+    }
+
+    let entityTypesDataTable :React$Node = (
+      <AbstractTypeDataTable
+          abstractTypes={entityTypes}
+          maxHeight={500}
+          workingAbstractTypeType={AbstractTypes.EntityTypes} />
+    );
+
+    if (AuthUtils.isAuthenticated() && AuthUtils.isAdmin()) {
+      entityTypesDataTable = (
+        <AbstractTypeDataTable
+            abstractTypes={entityTypes}
+            highlightOnHover
+            maxHeight={500}
+            onAbstractTypeRemove={this.handleOnEntityTypeRemove}
+            onReorder={this.handleOnEntityTypeReorder}
+            orderable
+            showRemoveColumn
+            workingAbstractTypeType={AbstractTypes.EntityType} />
+      );
+    }
+
+    return (
+      <section>
+        <h2>EntityTypes</h2>
+        { entityTypesDataTable }
+      </section>
+    );
+  }
+
   render() {
 
     if (!this.props.propertyType || this.props.propertyType.isEmpty()) {
@@ -55,6 +91,16 @@ class PropertyTypeDetailsContainer extends React.Component<Props> {
     const ptPII :boolean = this.props.propertyType.get('piiField', false);
     const piiAsString :string = ptPII === true ? 'true' : 'false';
 
+    const entityTypes :List<Map<*, *>> = entityTypeIds
+      .map((entityTypeId :string) => {
+        const index :number = this.props.entityTypesById.get(entityTypeId, -1);
+        if (index === -1) {
+          return Map();
+        }
+        return this.props.entityTypes.get(index, Map());
+      })
+      .toList();
+      
     return (
       <div>
         <h1>PropertyType Details</h1>
@@ -89,6 +135,7 @@ class PropertyTypeDetailsContainer extends React.Component<Props> {
           <h2>Analyzer</h2>
           <p>{ this.props.propertyType.get('analyzer') }</p>
         </section>
+        { this.renderEntityTypesSection(entityTypes) }
         {
           AuthUtils.isAuthenticated() && AuthUtils.isAdmin()
             ? (


### PR DESCRIPTION
Added feature to display the EntityTypes for which each PropertyType is a part of. This feature would be improved by including 'EntityTypes' into the PropertyType object, like how EntityType objects have 'properties' on the backend. Without, the feature relies on collecting all entityType objects from the edm and looking up to see whether the propertyType is included in it's 'properties'.